### PR TITLE
Restore the ability to encrypt a Slack API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ __NOTE: Ruby is required. I used Ruby version 2.2.2 and it worked.__
 
 Follow on-screen prompts:
 
-    python functions/invite/encrypt.py
+    python encrypt_token.py

--- a/encrypt_token.py
+++ b/encrypt_token.py
@@ -1,0 +1,24 @@
+from __future__ import print_function, unicode_literals
+import sys
+from functions.invite.encrypt import encrypt_slack_token, decrypt_slack_token
+
+if sys.version_info < (3, 0):
+    prompt = raw_input
+else:
+    prompt = input
+
+
+if __name__ == '__main__':
+
+    # initialization
+    plain_text = prompt('Enter the string to encrypt: ')
+
+    # encrypt the string and display
+    b64 = encrypt_slack_token(plain_text)
+    print()
+    print('Encrypted text: {0}'.format(b64))
+
+    # test decrypting and display the result
+    plain_text = decrypt_slack_token(b64)
+    print()
+    print('Decrypted text: {0}'.format(plain_text))


### PR DESCRIPTION
Partially implements https://github.com/unfoldingWord-dev/door43.org/issues/438